### PR TITLE
Planned tasks

### DIFF
--- a/ISOXML/TimeLogReader.cs
+++ b/ISOXML/TimeLogReader.cs
@@ -168,9 +168,9 @@ namespace ISOXML
                 }
             }
 
-            // Read binary timelog files
             foreach (var TSK in ISOTaskFile.Root.Descendants("TSK"))
             {
+                // Read XML-files of planned task
                 if (TSK.Attribute("G").Value == "1")
                 {
                     Console.WriteLine("Planned task:");
@@ -215,6 +215,7 @@ namespace ISOXML
 
                 else
                 {
+                    // Read binary timelog files of implemented task
                 foreach (var TLG in TSK.Descendants("TLG"))
                 {
                     TimeLogData TLGdata = new TimeLogData();

--- a/ISOXML/TimeLogReader.cs
+++ b/ISOXML/TimeLogReader.cs
@@ -173,26 +173,18 @@ namespace ISOXML
             {
                 if (TSK.Attribute("G").Value == "1")
                 {
-                    Console.WriteLine("Planned task");
+                    Console.WriteLine("Planned task:");
+                    Console.WriteLine(TSK.Attribute("A").Value);
                     TimeLogData TLGdata = new TimeLogData();
                     TLGdata.taskname = TSK.Attribute("B").Value;
-                    Console.WriteLine(TLGdata.taskname);
                     TLGdata.field = ISOTaskFile.Root.Descendants("PFD").Where(pdf => pdf.Attribute("A").Value == TSK.Attribute("E").Value).Single().Attribute("C").Value;
-                    Console.WriteLine(TLGdata.field);
 
                     if (ISOTaskFile.Root.Descendants("FRM").Count() > 0)
                     {
                         TLGdata.farm = ISOTaskFile.Root.Descendants("FRM").Where(frm => frm.Attribute("A").Value == TSK.Attribute("D").Value).Single().Attribute("B").Value;
                     }
 
-                    Console.WriteLine(TLGdata.farm);
-
                     TLGdata.products = products;
-
-                    foreach (var kvp in products)
-                            {
-                                Console.WriteLine($"{kvp.Key}: {kvp.Value}");
-                            }
 
                     List<Dictionary<string, string>> devicelist = new List<Dictionary<string, string>>();
                     List<string> devicerefs = TSK.Elements("DAN").Attributes("C").Select(attr => attr.Value).ToList();
@@ -208,6 +200,15 @@ namespace ISOXML
                     }
 
                     TLGdata.devices = devicelist;
+
+                    Console.WriteLine(TLGdata.taskname);
+                    Console.WriteLine(TLGdata.field);
+                    Console.WriteLine(TLGdata.farm);
+
+                    foreach (var kvp in products)
+                    {
+                        Console.WriteLine($"{kvp.Key}: {kvp.Value}");
+                    }
 
                     TLGList.Add(TLGdata);
                 }

--- a/ISOXML/TimeLogReader.cs
+++ b/ISOXML/TimeLogReader.cs
@@ -173,8 +173,6 @@ namespace ISOXML
                 // Read XML-files of planned task
                 if (TSK.Attribute("G").Value == "1")
                 {
-                    Console.WriteLine("Planned task:");
-                    Console.WriteLine(TSK.Attribute("A").Value);
                     TimeLogData TLGdata = new TimeLogData();
                     TLGdata.taskname = TSK.Attribute("B").Value;
                     TLGdata.field = ISOTaskFile.Root.Descendants("PFD").Where(pdf => pdf.Attribute("A").Value == TSK.Attribute("E").Value).Single().Attribute("C").Value;
@@ -183,15 +181,6 @@ namespace ISOXML
                     if (ISOTaskFile.Root.Descendants("FRM").Count() > 0)
                     {
                         TLGdata.farm = ISOTaskFile.Root.Descendants("FRM").Where(frm => frm.Attribute("A").Value == TSK.Attribute("D").Value).Single().Attribute("B").Value;
-                    }
-
-                    Console.WriteLine(TLGdata.taskname);
-                    Console.WriteLine(TLGdata.field);
-                    Console.WriteLine(TLGdata.farm);
-
-                    foreach (var kvp in products)
-                    {
-                        Console.WriteLine($"{kvp.Key}: {kvp.Value}");
                     }
 
                     TLGList.Add(TLGdata);

--- a/ISOXML/TimeLogReader.cs
+++ b/ISOXML/TimeLogReader.cs
@@ -171,6 +171,49 @@ namespace ISOXML
             // Read binary timelog files
             foreach (var TSK in ISOTaskFile.Root.Descendants("TSK"))
             {
+                if (TSK.Attribute("G").Value == "1")
+                {
+                    Console.WriteLine("Planned task");
+                    TimeLogData TLGdata = new TimeLogData();
+                    TLGdata.taskname = TSK.Attribute("B").Value;
+                    Console.WriteLine(TLGdata.taskname);
+                    TLGdata.field = ISOTaskFile.Root.Descendants("PFD").Where(pdf => pdf.Attribute("A").Value == TSK.Attribute("E").Value).Single().Attribute("C").Value;
+                    Console.WriteLine(TLGdata.field);
+
+                    if (ISOTaskFile.Root.Descendants("FRM").Count() > 0)
+                    {
+                        TLGdata.farm = ISOTaskFile.Root.Descendants("FRM").Where(frm => frm.Attribute("A").Value == TSK.Attribute("D").Value).Single().Attribute("B").Value;
+                    }
+
+                    Console.WriteLine(TLGdata.farm);
+
+                    TLGdata.products = products;
+
+                    foreach (var kvp in products)
+                            {
+                                Console.WriteLine($"{kvp.Key}: {kvp.Value}");
+                            }
+
+                    List<Dictionary<string, string>> devicelist = new List<Dictionary<string, string>>();
+                    List<string> devicerefs = TSK.Elements("DAN").Attributes("C").Select(attr => attr.Value).ToList();
+
+                    foreach (var deviceref in devicerefs)
+                    {
+                        Dictionary<string, string> devicedict = new Dictionary<string, string>();
+                        string devicename = ISOTaskFile.Root.Descendants("DVC").Single(dvc => dvc.Attribute("A").Value == deviceref).Attribute("B").Value;
+                        string clientname = ISOTaskFile.Root.Descendants("DVC").Single(dvc => dvc.Attribute("A").Value == deviceref).Attribute("D").Value;
+                        devicedict.Add("device", devicename);
+                        devicedict.Add("clientname", clientname);
+                        devicelist.Add(devicedict);
+                    }
+
+                    TLGdata.devices = devicelist;
+
+                    TLGList.Add(TLGdata);
+                }
+
+                else
+                {
                 foreach (var TLG in TSK.Descendants("TLG"))
                 {
                     TimeLogData TLGdata = new TimeLogData();

--- a/ISOXML/TimeLogReader.cs
+++ b/ISOXML/TimeLogReader.cs
@@ -438,13 +438,11 @@ namespace ISOXML
                     reader.Close();
                     TLGList.Add(TLGdata);
                 }
+                }
 
 
             }
             return TLGList;
         }
-
-
-
     }
 }

--- a/ISOXML/TimeLogReader.cs
+++ b/ISOXML/TimeLogReader.cs
@@ -178,28 +178,12 @@ namespace ISOXML
                     TimeLogData TLGdata = new TimeLogData();
                     TLGdata.taskname = TSK.Attribute("B").Value;
                     TLGdata.field = ISOTaskFile.Root.Descendants("PFD").Where(pdf => pdf.Attribute("A").Value == TSK.Attribute("E").Value).Single().Attribute("C").Value;
+                    TLGdata.products = products;
 
                     if (ISOTaskFile.Root.Descendants("FRM").Count() > 0)
                     {
                         TLGdata.farm = ISOTaskFile.Root.Descendants("FRM").Where(frm => frm.Attribute("A").Value == TSK.Attribute("D").Value).Single().Attribute("B").Value;
                     }
-
-                    TLGdata.products = products;
-
-                    List<Dictionary<string, string>> devicelist = new List<Dictionary<string, string>>();
-                    List<string> devicerefs = TSK.Elements("DAN").Attributes("C").Select(attr => attr.Value).ToList();
-
-                    foreach (var deviceref in devicerefs)
-                    {
-                        Dictionary<string, string> devicedict = new Dictionary<string, string>();
-                        string devicename = ISOTaskFile.Root.Descendants("DVC").Single(dvc => dvc.Attribute("A").Value == deviceref).Attribute("B").Value;
-                        string clientname = ISOTaskFile.Root.Descendants("DVC").Single(dvc => dvc.Attribute("A").Value == deviceref).Attribute("D").Value;
-                        devicedict.Add("device", devicename);
-                        devicedict.Add("clientname", clientname);
-                        devicelist.Add(devicedict);
-                    }
-
-                    TLGdata.devices = devicelist;
 
                     Console.WriteLine(TLGdata.taskname);
                     Console.WriteLine(TLGdata.field);


### PR DESCRIPTION
- parses basic information of planned task from TASKDATA.XML (still saved to TimeLogData object, might be misleading)
- identifies planned task from TASKDATA.XML attributes and skips further TimeLogData processing in order to avoid errors